### PR TITLE
Jsonschema

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,6 +1,16 @@
 const compile = require('./')
 
-const dave = {"checked":true,"checker":false,"dimensions":{"height":10,"width":5},"id":1,"name":"A green door","price":12}
+const dave = {
+  checked: true,
+  checker: false,
+  dimensions: {
+    height: 10,
+    width: 5
+  },
+  id: 1,
+  name: 'A green door',
+  price: 12
+}
 
 const s = JSON.stringify(dave)
 const b = Buffer.from(s)
@@ -10,29 +20,28 @@ const parse = compile(schema, {optional: false, validate: false, unsafe: false, 
 
 const parseNoBuf = compile(schema, {optional: false, validate: false, unsafe: false, unescapeStrings: false})
 
-
 console.log('Generated code:')
 console.log(parse.toString())
 console.log('One parse:')
 console.log(parse(s, b))
 
 const cnt = 3e7
+var i
 
 console.time('Benching turbo-json-parse with buffer')
-for (var i = 0; i < cnt; i++) {
+for (i = 0; i < cnt; i++) {
   parse(s, b)
 }
 console.timeEnd('Benching turbo-json-parse with buffer')
 
 console.time('Benching turbo-json-parse without buffer')
-for (var i = 0; i < cnt; i++) {
+for (i = 0; i < cnt; i++) {
   parseNoBuf(s)
 }
 console.timeEnd('Benching turbo-json-parse without buffer')
 
-
 console.time('Benching JSON.parse')
-for (var i = 0; i < cnt; i++) {
+for (i = 0; i < cnt; i++) {
   JSON.parse(s)
 }
 console.timeEnd('Benching JSON.parse')

--- a/example.js
+++ b/example.js
@@ -17,4 +17,3 @@ const ex = JSON.stringify({
 
 // will return {hello: 'world'}
 console.log(parse(ex))
-

--- a/index.js
+++ b/index.js
@@ -1,395 +1,157 @@
+/* eslint no-new-func: 0 */
+'use strict'
+
 const genfun = require('generate-function')
 
-compile.schema = types
-module.exports = compile
-
-function def (type) {
-  if (typeof type === 'string') {
-    switch (type) {
-      case 'string': return '""'
-      case 'number': return '0'
-      case 'boolean':
-      case 'bool': return 'false'
-      default: throw new Error('Not default type available')
-    }
-  }
-  return 'undefined'
-}
-
-function endNumberString (s, ptr) {
-  for (; ptr < s.length; ptr++) {
-    switch (s.charCodeAt(ptr)) {
-      case 44:
-      case 93:
-      case 125:
-      return ptr
-    }
-  }
-  throw new Error('Could not find end of number')
-}
-
-function endNumberBuffer (b, ptr) {
-  for (; ptr < b.length; ptr++) {
-    switch (b[ptr]) {
-      case 44:
-      case 93:
-      case 125:
-      return ptr
-    }
-  }
-  throw new Error('Could not find end of number')
-}
-
-function indexOfString (s, val, offset) {
-  const i = s.indexOf(val, offset)
-  if (i === -1) throw new Error('Could not parse value')
-  return i
-}
-
-function indexOfKey (keys, val, offset) {
-  const i = keys.indexOf(val, offset)
-  if (i === -1) throw new Error('Unknown key: ' + val)
-  return i
-}
-
-function types (obj) {
-  const t = typeof obj
-  switch (t) {
-    case 'number': return 'number'
-    case 'string': return 'string'
-    case 'boolean': return 'boolean'
-  }
-
-  if (!obj) throw new Error('Cannot infer type')
-
-  if (Array.isArray(obj)) {
-    return [types(obj[0])]
-  }
-
-  const schema = {}
-
-  for (const k of Object.keys(obj)) {
-    schema[k] = types(obj[k])
-  }
-
-  return schema
-}
-
-function isObject (v) {
-  return typeof v === 'object' && !Array.isArray(v)
-}
-
-function bool (v, def) {
-  return typeof v === 'boolean' ? v : def
-}
-
-function stringUnescape (s) {
-  if (s.indexOf('\\') === -1) return s
-  return slowStringUnescape(s)
-}
-
-function slowStringUnescape (s) {
-  return JSON.parse('"' + s + '"') // slow path but unlikely
-}
-
-function compile (schema, opts) {
-  if (!opts) opts = {}
-
-  const unsafe = bool(opts.unsafe, false)
-  const validate = bool(opts.validate, !unsafe)
-  const optional = bool(opts.optional, true)
-  const unescapeStrings = bool(opts.unescapeStrings, true)
-  const validateKeys = bool(opts.validateKeys, !unsafe)
-  const validateLength = bool(opts.validateLength, !unsafe)
-  const buffer = !!opts.buffer
-
-  var tick = 0
-  var incs = 0
-  var absVar = ''
-  var declaredPtr = false
-
-  const constants = {endNumber, indexOfString, indexOfKey, endNumberBuffer, endNumberString, stringUnescape}
+module.exports = function (schema) {
   const gen = genfun()
 
-  if (typeof schema !== 'object') throw new Error('Only object or array schemas supported')
+  const constants = {}
 
-  gen('function parse (s, b) {')
-  compileType(null, schema, gen)
-  gen('}')
-
-  return gen.toFunction(constants)
-
-  function inc (n, abs) {
-    if (abs) {
-      absVar = abs
-      incs = n
-    } else {
-      incs += n
-    }
-  }
-
-  function flush () {
-    const decl = declaredPtr ? 'ptr' : 'var ptr'
-    if (absVar) {
-      gen('%s = %s + %d', decl, absVar, incs)
-      incs = 0
-      absVar = ''
-    } else if (incs) {
-      const plus = declaredPtr ? '+=' : '='
-      gen('%s %s %d', decl, plus, incs)
-      incs = 0
-    } else if (!declaredPtr) {
-      gen('%s = 0', decl)
-    }
-    declaredPtr = true
-  }
+  var tick = 0
 
   function tmp () {
     return 'tmp' + (tick++)
   }
 
-  function defaultObj (obj, fields) {
+  function def (type) {
+    if (typeof type === 'string') {
+      switch (type) {
+        case 'string': return '""'
+        case 'number': return '0'
+        case 'boolean':
+        case 'bool': return 'false'
+        case 'array': return '[]'
+        case 'object': return '{}'
+        default: throw new Error('Not default type available')
+      }
+    }
+    return 'undefined'
+  }
+
+  function defaultObj (schema, fields) {
     for (var j = 0; j < fields.length; j++) {
       const name = fields[j]
       const sep = j < fields.length - 1 ? ',' : ''
-      const child = obj[name]
-      if (isObject(child) && !optional) {
-        gen('%s: {', name)
-        defaultObj(child, Object.keys(child))
-        gen('}%s', sep)
-      } else if (Array.isArray(child) && !optional) {
-        gen('%s: []%s', name, sep)
-      } else {
-        gen('%s: %s%s', name, def(child), sep)
-      }
+      const child = schema.properties[name]
+      gen('%s: %s%s', name, def(child.type), sep)
     }
   }
 
-  function ch (i) {
-    return buffer ? 'b[' + i + ']' : 's.charCodeAt(' + i + ')'
+  function generateString (fieldName, startValueVar) {
+    gen(`if (s.charCodeAt(ptr++) !== 34) throw new Error("Cannot parse object")`)
+    gen('%s = ptr', startValueVar)
+    gen(`while (s.charCodeAt(++ptr) !== 34) ;`)
+    gen('ptr += 1')
   }
 
-  function idxOf (ch, offset) {
-    // buffer.indexOf seems to always be slower than s.indexOf?
-    // 'indexOfBuffer(b, ' + ch + ', ' + offset + ')'
-    return 'indexOfString(s, ' + JSON.stringify(String.fromCharCode(ch)) + ', ' + offset + ')'
+  function generateNumber (startValueVar) {
+    const temp = tmp()
+    gen('%s = ptr', startValueVar)
+    gen('var %s', temp)
+    gen(`for (; ptr < s.length; ptr++) {`)
+    gen('%s = s.charCodeAt(ptr)', temp)
+    gen(`if (%s > 57 || %s < 48) break`, temp, temp)
+    gen('}')
   }
 
-  function compareKey (f, fields, i, offset, eq) {
-    const name = fields[i]
-    const cmp = eq ? ' === ' : ' !== '
-    const join = eq ? ' && ' : ' || '
-
-    if (buffer) {
-      const s = eq ? 'ptr + ' + (name.length + offset) + ' < b.length' + join : ''
-      return s + name.split('').map(function (ch, j) {
-        const ptr = offset + j ? 'ptr + ' + (offset + j) : 'ptr'
-        return 'b[' + ptr + ']' + cmp + ch.charCodeAt(0)
-      }).join(join)
-    }
-
-    const end = name.length + offset
-    return f + '[' + i + ']' + cmp + 's.slice(ptr + ' + offset + ', ptr + ' + end + ')'
+  function generateBoolean (startValueVar) {
+    gen('if (s.charCodeAt(ptr) === 116) {')
+    gen('if (s.charCodeAt(ptr + 1) !== 114 || s.charCodeAt(ptr + 2) !== 117 || s.charCodeAt(ptr + 3) !== 101) throw new Error("Cannot parse object")')
+    gen(`%s = true`, startValueVar)
+    gen('ptr += 4')
+    gen('} else {')
+    gen('if (s.charCodeAt(ptr) !== 102 || s.charCodeAt(ptr + 1) !== 97 || s.charCodeAt(ptr + 2) !== 108 || s.charCodeAt(ptr + 3) !== 115 || s.charCodeAt(ptr + 4) !== 101) throw new Error("Cannot parse object")')
+    gen(`%s = false`, startValueVar)
+    gen('ptr += 5')
+    gen('}')
   }
 
-  function compileObject (assign, obj, gen, parent) {
-    const t = tmp()
-    const f = tmp()
-    const fields = constants[f] = Object.keys(obj)
+  function createObj (schema, t) {
+    const fields = Object.keys(schema.properties)
 
-    if (parent) {
-      gen('const %s = %s', t, parent)
-    } else {
-      gen('const %s = {', t)
-      defaultObj(obj, fields)
+    if (!/\./.test(t)) {
+      gen('var %s = {', t)
+      defaultObj(schema, fields)
       gen('}')
     }
-
-    if (fields.length === 0) {
-      inc(2)
-    } else {
-      if (validate) {
-        flush()
-        gen(`if (${ch('ptr')} !== 123) throw new Error("Cannot parse object")`)
-      }
-      if (optional) {
-        flush()
-        gen(`if (${ch('ptr + 1')} === 125) {`)
-          ('ptr += 2')
-        gen('} else {')
-      }
-
-      for (var j = 0; j < fields.length; j++) {
-        const name = fields[j]
-        const type = obj[name]
-        const parent = t + '.' + name
-        const assign = val => parent + ' = ' + val
-        const offset = (!optional && j === 0) ? 1 : 0
-        if (j === 0 && optional) inc(1)
-        if (optional) {
-          flush()
-          gen('if (%s) {', compareKey(f, fields, j, offset + 1, true))
-        } else if (validateKeys) {
-          flush()
-          gen('if (%s) throw new Error("Missing key: %s")', compareKey(f, fields, j, offset + 1), name)
-        }
-        if (validate) {
-          flush()
-          gen(`if (${ch('ptr + %d')} !== 58) throw new Error("Cannot parse object")`, name.length + 2 + offset)
-        }
-        inc(name.length + 3 + offset)
-        compileType(assign, type, gen, !optional && parent)
-        if (optional) {
-          flush()
-          gen('}')
-        }
-      }
-
-      if (optional) gen('}')
-    }
-
-    if (assign) {
-      inc(1)
-      if (!parent) gen(assign(t))
-      return
-    }
-
-    if (validate) {
-      flush()
-      gen(`if (${ch('ptr - 1')} !== 125) throw new Error("Cannot parse object")`)
-    }
-
-    if (validateLength) {
-      flush()
-      gen('if (ptr !== s.length) throw new Error("Object contains extra data")')
-    }
-
-    gen('return %s', t)
-  }
-
-  function compileType (assign, type, gen, parent) {
-    if (typeof type === 'string') {
+    gen(`if (s.charCodeAt(ptr) !== 123) throw new Error("Cannot parse object")`)
+    gen(`if (s.charCodeAt(ptr + 1) === 125) {`)
+    gen('ptr += 2')
+    gen('} else {')
+    const startValueVar = tmp()
+    gen('var %s', startValueVar)
+    for (var j = 0; j < fields.length; j++) {
+      var jj = tmp()
+      const fieldName = fields[j]
+      constants[jj] = fieldName
+      const type = schema.properties[fieldName].type
+      gen(`if (%s !== s.slice(ptr + 2, ptr + ${fieldName.length + 2})) throw new Error("Unexpected key")`, jj)
+      // gen(`if (s.charCodeAt(ptr + ${fieldName.length + 2}) !== 34) throw new Error("Cannot parse object")`)
+      gen(`if (s.charCodeAt(ptr + ${fieldName.length + 3}) !== 58) throw new Error("Cannot parse object")`)
+      gen(`ptr += ${fieldName.length + 4}`)
       switch (type) {
-        case 'string': return compileString(assign, gen, parent)
-        case 'number': return compileNumber(assign, gen, parent)
+        case 'string':
+          generateString(fieldName, startValueVar)
+          gen(`%s.${fieldName} = s.slice(%s, %s - 1)`, t, startValueVar, 'ptr')
+          break
+        case 'number':
+          generateNumber(startValueVar)
+          gen(`%s.${fieldName} = Number(s.slice(%s, %s))`, t, startValueVar, 'ptr')
+          break
         case 'boolean':
-        case 'bool': return compileBool(assign, gen, parent)
-        default: throw new Error('Unknown type: ' + type)
+          generateBoolean(startValueVar)
+          gen(`%s.${fieldName} = %s`, t, startValueVar)
+          break
+        case 'array':
+          gen(`if (s.charCodeAt(ptr++) !== 91) throw new Error("Cannot parse object")`)
+          gen(`while (s.charCodeAt(ptr) !== 93) {`)
+          switch (schema.properties[fieldName].items.type) {
+            case 'string':
+              generateString(fieldName, startValueVar)
+              gen(`%s.${fieldName}.push(s.slice(%s, %s - 1))`, t, startValueVar, 'ptr')
+              break
+            case 'number':
+              generateNumber(startValueVar)
+              gen(`%s.${fieldName}.push(Number(s.slice(%s, %s)))`, t, startValueVar, 'ptr')
+              break
+            case 'boolean':
+              generateBoolean(startValueVar)
+              gen(`%s.${fieldName}.push(%s)`, t, startValueVar)
+              break
+          }
+          // gen('ptr+=1')
+          gen('ptr+=1')
+          gen(`if (s.charCodeAt(ptr - 1) === 93) break`)
+          gen('}')
+          break
+        case 'object':
+          createObj(schema.properties[fieldName], t + '.' + fieldName)
+          break
+        default:
+          throw new Error('Unknown type: ' + type)
+      }
+      if (j !== fields.length - 1) {
+        gen(`if (s.charCodeAt(ptr) !== 44) throw new Error("Cannot parse object")`)
+      } else {
+        gen('ptr += 1')
       }
     }
-
-    if (Array.isArray(type)) return compileArray(assign, type[0], gen, parent)
-    return compileObject(assign, type, gen, parent)
+    gen(`}`)
   }
 
-  function compileArray (assign, type, gen, parent) {
-    const t = tmp()
-
-    if (parent) {
-      gen('const %s = %s', t, parent)
-    } else {
-      gen('const %s = []', t)
-    }
-
-    if (validate) {
-      flush()
-      gen(`if (${ch('ptr')} !== 91) throw new Error("Cannot parse array")`)
-    }
-
-    flush()
-    gen(`if (++ptr < s.length && ${ch('ptr')} !== 93) {`)
-      ('do {')
-
-    compileType(val => t + '.push(' + val + ')', type, gen)
-    flush()
-
-    gen(`} while (ptr < s.length && ${ch('ptr - 1')} !== 93)`)
-      ('}')
-
-    if (assign) {
-      inc(1)
-      if (!parent) gen(assign(t))
-      return
-    }
-
-    if (validate) {
-      gen(`if (${ch('ptr - 1')} !== 93) throw new Error("Cannot parse array")`)
-    }
-
-    if (validateLength) {
-      flush()
-      gen('if (ptr !== s.length) throw new Error("Object contains extra data")')
-    }
-
-    gen('return %s', t)
+  const t = tmp()
+  gen('function parse (s, b) {')
+  gen('var ptr = 0')
+  switch (schema.type) {
+    case 'object':
+      createObj(schema, t)
+      gen(`if (s.charCodeAt(ptr - 1) !== 125) throw new Error("Cannot parse object")`)
+      gen(`if (ptr !== s.length) throw new Error("Object contains extra data")`)
+      break
   }
+  gen('return %s', t)
+  gen('}')
 
-  function compileString (assign, gen) {
-    flush()
-
-    const t = tmp()
-
-    if (validate) {
-      gen(`if (${ch('ptr')} !== 34) throw new Error("Cannot parse string")`)
-    }
-
-    gen(`var %s = ${idxOf(34, '++ptr')}`, t)
-
-    gen(`while (${ch('%s - 1')} === 92) {`, t)
-      (`%s = ${idxOf(34, '%s + 1')}`, t, t)
-    gen('}')
-
-    if (unescapeStrings) {
-      gen(assign('stringUnescape(s.slice(ptr, %s))'), t)
-    } else {
-      gen(assign('s.slice(ptr, %s)'), t)
-    }
-    inc(2, t)
-  }
-
-  function endNumber (ptr) {
-    return buffer
-      ? 'endNumberBuffer(b, ' + ptr + ')'
-      : 'endNumberString(s, ' + ptr + ')'
-  }
-
-  function compileNumber (assign, gen, parent) {
-    flush()
-
-    const t = tmp()
-    const n = parent || tmp()
-    const decl = parent ? n : 'const ' + n
-
-    gen(`const %s = ${endNumber('ptr')}`, t)
-    gen('%s = Number(s.slice(ptr, %s))', decl, t)
-
-    if (validate) {
-      gen('if (isNaN(%s)) throw new Error("Cannot parse number")', n)
-    }
-
-    if (!parent) gen(assign('%s'), n)
-    inc(1, t)
-  }
-
-  function compileBool (assign, gen) {
-    flush()
-
-    gen(`if (${ch('ptr')} === 116) {`)
-      (assign('true'))
-      ('ptr += 5')
-
-    if (validate) {
-      gen(`} else if (${ch('ptr')} === 102) {`)
-        (assign('false'))
-        ('ptr += 6')
-      ('} else {')
-        ('throw new Error("Could not parse boolean")')
-      ('}')
-    } else {
-      gen('} else {')
-        (assign('false'))
-        ('ptr += 6')
-      ('}')
-     }
-  }
+  return gen.toFunction(constants)
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,20 @@
   "version": "1.1.0",
   "description": "Turbocharged JSON.parse for type stable JSON data",
   "main": "index.js",
+  "scripts": {
+    "unit": "tap test.js",
+    "lint": "standard *.js",
+    "test": "npm run lint && npm run unit"
+  },
   "dependencies": {
     "generate-function": "^2.0.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "benchmark": "^2.1.4",
+    "microtime": "^2.1.8",
+    "standard": "^11.0.1",
+    "tap": "^12.0.1"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/mafintosh/turbo-json-parse.git"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "benchmark": "^2.1.4",
     "microtime": "^2.1.8",
+    "pre-commit": "^1.2.2",
     "standard": "^11.0.1",
     "tap": "^12.0.1"
   },

--- a/test.js
+++ b/test.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const t = require('tap')
+const tjp = require('./index')
+
+t.test('turbo json parse', t => {
+  t.test('object - string property', t => {
+    const p = tjp({ type: 'object', properties: { key1: { type: 'string' } } })
+    t.strictSame(p('{"key1":"value1"}'), { key1: 'value1' })
+    t.end()
+  })
+
+  t.test('object - two string property', t => {
+    const p = tjp({ type: 'object', properties: { key1: { type: 'string' }, key2: { type: 'string' } } })
+    t.strictSame(p('{"key1":"value1","key2":"value2"}'), { key1: 'value1', key2: 'value2' })
+    t.end()
+  })
+
+  t.test('object - number property', t => {
+    const p = tjp({ type: 'object', properties: { key1: { type: 'number' } } })
+    t.strictSame(p('{"key1":554}'), { key1: 554 })
+    t.end()
+  })
+
+  t.test('object - boolean property', t => {
+    const p = tjp({ type: 'object', properties: { key1: { type: 'boolean' } } })
+    t.strictSame(p('{"key1":true}'), { key1: true })
+    t.strictSame(p('{"key1":false}'), { key1: false })
+    t.end()
+  })
+
+  t.test('object - array - string property', t => {
+    const p = tjp({ type: 'object', properties: { key1: { type: 'array', items: { type: 'string' } } } })
+    t.strictSame(p('{"key1":["qq"]}'), { key1: ['qq'] })
+    t.strictSame(p('{"key1":["qq","rr"]}'), { key1: ['qq', 'rr'] })
+    t.strictSame(p('{"key1":["qq","rr","rrrrr"]}'), { key1: ['qq', 'rr', 'rrrrr'] })
+    t.end()
+  })
+
+  t.test('object - array - number property', t => {
+    const p = tjp({ type: 'object', properties: { key1: { type: 'array', items: { type: 'number' } } } })
+    t.strictSame(p('{"key1":[55]}'), { key1: [55] })
+    t.strictSame(p('{"key1":[55,66]}'), { key1: [55, 66] })
+    t.end()
+  })
+
+  t.test('object - array - boolean property', t => {
+    const p = tjp({ type: 'object', properties: { key1: { type: 'array', items: { type: 'boolean' } } } })
+    t.strictSame(p('{"key1":[true]}'), { key1: [true] })
+    t.strictSame(p('{"key1":[false]}'), { key1: [false] })
+    t.strictSame(p('{"key1":[true,false]}'), { key1: [true, false] })
+    t.strictSame(p('{"key1":[false,true]}'), { key1: [false, true] })
+    t.end()
+  })
+
+  t.test('object - object - string property', t => {
+    const p = tjp({ type: 'object', properties: { key1: { type: 'object', properties: { key2: { type: 'string' } } } } })
+    t.strictSame(p('{"key1":{"key2":"foo"}}'), { key1: { key2: 'foo' } })
+    t.end()
+  })
+
+  t.end()
+})


### PR DESCRIPTION
Fix #3 
This PR introduces the JSONSchema based parser.
I have used `standard` and `tap` but only because I used to use them. I'll open to change that.

For the current supported feature, see test.

I've tested the benchmark too. In many circumstance the new generated code is faster then the older. Only on testing `boolean` value, the new code is slower then the older because the new code tests the "true" or "false" string entirely.

The options of the old code is not ported here because I need to know if you are interested in this PR before continuing it.