### PR TITLE
Require generate-function@^2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Turbocharged JSON.parse for type stable JSON data",
   "main": "index.js",
   "dependencies": {
-    "generate-function": "^2.0.0"
+    "generate-function": "^2.2.0"
   },
   "devDependencies": {
     "standard": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Turbocharged JSON.parse for type stable JSON data",
   "main": "index.js",
   "dependencies": {
-    "generate-function": "^2.2.0"
+    "generate-function": "^2.2.1"
   },
   "devDependencies": {
     "standard": "^11.0.1",


### PR DESCRIPTION
I was getting these errors after doing `git pull && npm install` in clinic doctor:

```
/home/goto-bus-stop/Code/nearform/node-clinic-doctor/node_modules/turbo-json-parse/index.js:27
  gen.scope.console = console
                    ^
TypeError: Cannot set property 'console' of undefined
    at compile (/home/goto-bus-stop/Code/nearform/node-clinic-doctor/node_modules/turbo-json-parse/index.js:27:21)
```

Because I still had an old generate-function version in the node_modules
tree, and npm considered it up to date enough.

Since turbo-json-parse uses functionality from v2.2.0 now it should also depend on 2.2.0+