### PR TITLE
Fix compilation of special property names

### DIFF
--- a/lib/array.js
+++ b/lib/array.js
@@ -14,7 +14,8 @@ function defaults (opts) {
     const assigning = !prop || !prop.getable
     const allowEmpty = rawSchema.allowEmpty !== false && allowEmptyArrays
 
-    const a = assigning ? gen.sym(rawSchema.name || 'arr') : prop.get()
+    const rawName = assigning ? gen.sym(rawSchema.name || 'arr') : prop.get()
+    const a = `variable${rawName}`.replace(/ /g, '_')
 
     if (assigning) {
       gen(`const ${a} = []`)

--- a/lib/array.js
+++ b/lib/array.js
@@ -14,8 +14,7 @@ function defaults (opts) {
     const assigning = !prop || !prop.getable
     const allowEmpty = rawSchema.allowEmpty !== false && allowEmptyArrays
 
-    const rawName = assigning ? gen.sym(rawSchema.name || 'arr') : prop.get()
-    const a = `variable${rawName}`.replace(/ /g, '_')
+    const a = assigning ? gen.sym(rawSchema.name || 'arr') : prop.get()
 
     if (assigning) {
       gen(`const ${a} = []`)

--- a/lib/object.js
+++ b/lib/object.js
@@ -86,7 +86,8 @@ function defaults (opts) {
       rawSchema.allowEmpty !== false &&
       allowEmptyObjects
 
-    const o = assigning ? gen.sym(rawSchema.name || 'o') : prop.get()
+    const rawName = assigning ? gen.sym(rawSchema.name || 'o') : prop.get()
+    const o = `variable${rawName}`.replace(/ /g, '_')
     const reqs = new Required(gen, o, fields)
 
     if (assigning) {
@@ -199,28 +200,28 @@ function defaults (opts) {
 
       switch (f.type) {
         case schema.STRING:
-          gen(`${f.name}: ${JSON.stringify(f.default || '')}${s}`)
+          gen(`['${f.name}']: ${JSON.stringify(f.default || '')}${s}`)
           break
         case schema.NUMBER:
-          gen(`${f.name}: ${f.default || 0}${s}`)
+          gen(`['${f.name}']: ${f.default || 0}${s}`)
           break
         case schema.BOOLEAN:
-          gen(`${f.name}: ${f.default || false}${s}`)
+          gen(`['${f.name}']: ${f.default || false}${s}`)
           break
         case schema.ARRAY:
           if (isRequired(f)) {
-            gen(`${f.name}: []${s}`)
+            gen(`['${f.name}']: []${s}`)
           } else {
-            gen(`${f.name}: undefined${s}`)
+            gen(`['${f.name}']: undefined${s}`)
           }
           break
         case schema.OBJECT:
           if (isRequired(f)) {
-            gen(`${f.name}: {`)
+            gen(`['${f.name}']: {`)
             defaultFields(gen, f.fields)
             gen(`}${s}`)
           } else {
-            gen(`${f.name}: undefined${s}`)
+            gen(`['${f.name}']: undefined${s}`)
           }
           break
       }

--- a/lib/object.js
+++ b/lib/object.js
@@ -3,6 +3,7 @@ const opsDefaults = require('./ops')
 const Property = require('./property')
 const similar = require('./similar')
 const schema = require('./schema')
+const {property} = require('generate-object-property')
 
 module.exports = defaults
 
@@ -200,28 +201,28 @@ function defaults (opts) {
 
       switch (f.type) {
         case schema.STRING:
-          gen(`['${f.name}']: ${JSON.stringify(f.default || '')}${s}`)
+          gen(`${property(f.name)}: ${JSON.stringify(f.default || '')}${s}`)
           break
         case schema.NUMBER:
-          gen(`['${f.name}']: ${f.default || 0}${s}`)
+          gen(`${property(f.name)}: ${f.default || 0}${s}`)
           break
         case schema.BOOLEAN:
-          gen(`['${f.name}']: ${f.default || false}${s}`)
+          gen(`${property(f.name)}: ${f.default || false}${s}`)
           break
         case schema.ARRAY:
           if (isRequired(f)) {
-            gen(`['${f.name}']: []${s}`)
+            gen(`${property(f.name)}: []${s}`)
           } else {
-            gen(`['${f.name}']: undefined${s}`)
+            gen(`${property(f.name)}: undefined${s}`)
           }
           break
         case schema.OBJECT:
           if (isRequired(f)) {
-            gen(`['${f.name}']: {`)
+            gen(`${property(f.name)}: {`)
             defaultFields(gen, f.fields)
             gen(`}${s}`)
           } else {
-            gen(`['${f.name}']: undefined${s}`)
+            gen(`${property(f.name)}: undefined${s}`)
           }
           break
       }

--- a/lib/object.js
+++ b/lib/object.js
@@ -87,8 +87,7 @@ function defaults (opts) {
       rawSchema.allowEmpty !== false &&
       allowEmptyObjects
 
-    const rawName = assigning ? gen.sym(rawSchema.name || 'o') : prop.get()
-    const o = `variable${rawName}`.replace(/ /g, '_')
+    const o = assigning ? gen.sym(rawSchema.name || 'o') : prop.get()
     const reqs = new Required(gen, o, fields)
 
     if (assigning) {

--- a/lib/property.js
+++ b/lib/property.js
@@ -2,7 +2,7 @@ module.exports = class Property {
   constructor (gen, object, field) {
     this.name = field.name || null
     this.parent = object || null
-    this.key = this.name ? object + '.' + this.name : null
+    this.key = this.name ? object + '[\'' + this.name + '\']' : null
     this.getable = field.required && !!this.key
     this.gen = gen
   }
@@ -16,7 +16,7 @@ module.exports = class Property {
   get () {
     if (!this.getable) throw new Error('Property is not getable')
     const sym = this.gen.sym(this.name)
-    this.gen(`const ${sym} = ${this.key}`)
+    this.gen(`const variable${sym.replace(/ /g, '_')} = ${this.key}`)
     return sym
   }
 }

--- a/lib/property.js
+++ b/lib/property.js
@@ -18,7 +18,7 @@ module.exports = class Property {
   get () {
     if (!this.getable) throw new Error('Property is not getable')
     const sym = this.gen.sym(this.name)
-    this.gen(`const variable${sym} = ${this.key}`)
+    this.gen(`const ${sym} = ${this.key}`)
     return sym
   }
 }

--- a/lib/property.js
+++ b/lib/property.js
@@ -1,8 +1,10 @@
+const generateObjectProperty = require('generate-object-property')
+
 module.exports = class Property {
   constructor (gen, object, field) {
     this.name = field.name || null
     this.parent = object || null
-    this.key = this.name ? object + '[\'' + this.name + '\']' : null
+    this.key = this.name ? generateObjectProperty(object, this.name) : null
     this.getable = field.required && !!this.key
     this.gen = gen
   }

--- a/lib/property.js
+++ b/lib/property.js
@@ -18,7 +18,7 @@ module.exports = class Property {
   get () {
     if (!this.getable) throw new Error('Property is not getable')
     const sym = this.gen.sym(this.name)
-    this.gen(`const variable${sym.replace(/ /g, '_')} = ${this.key}`)
+    this.gen(`const variable${sym} = ${this.key}`)
     return sym
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Turbocharged JSON.parse for type stable JSON data",
   "main": "index.js",
   "dependencies": {
-    "generate-function": "^2.2.1"
+    "generate-function": "^2.2.1",
+    "generate-object-property": "^1.2.0"
   },
   "devDependencies": {
     "standard": "^11.0.1",

--- a/test/test.js
+++ b/test/test.js
@@ -350,7 +350,74 @@ t.test('turbo-json-parse', t => {
       })
     })
 
+    t.test('object', t => {
+      t.test('protected keyword', t => {
+        const parser = tjp({
+          type: 'object',
+          properties: {
+            default: { type: 'string' }
+          }
+        })
+        t.deepEqual(parser('{"default":"value1"}'), { default: 'value1' })
+
+        t.end()
+      })
+    })
+
     t.end()
+  })
+
+  t.test('object', t => {
+    t.test('numeric property name', t => {
+      const parser = tjp({
+        type: 'object',
+        properties: {
+          42: { type: 'string' }
+        }
+      })
+      t.deepEqual(parser('{"42":"value1"}'), { 42: 'value1' })
+
+      t.end()
+    })
+  })
+
+  t.test('object', t => {
+    t.test('property name with whitespace', t => {
+      const parser = tjp({
+        type: 'object',
+        properties: {
+          // eslint-disable-next-line no-useless-computed-key
+          ['hello world']: {
+            type: 'object',
+            properties: {
+              key1: {
+                type: 'string'
+              }
+            }
+          }
+        }
+      })
+      const actual = parser('{"hello world":{"key1":"value1"}}')
+      // eslint-disable-next-line no-useless-computed-key
+      const expected = {['hello world']: {key1: 'value1'}}
+      t.deepEqual(actual, expected)
+
+      t.end()
+    })
+
+    t.test('property name with whitespace', t => {
+      const parser = tjp({
+        type: 'object',
+        properties: {
+          // eslint-disable-next-line no-useless-computed-key
+          ['hello world']: { type: 'string' }
+        }
+      })
+      // eslint-disable-next-line no-useless-computed-key
+      t.deepEqual(parser('{"hello world":"value1"}'), { ['hello world']: 'value1' })
+
+      t.end()
+    })
   })
 
   t.end()


### PR DESCRIPTION
This fixes invalid javascript being generated for the following cases:
- numeric property names
- property names being protected keywords
- property names with spaces 

Such property names are valid in json but are problematic when used directly as variable names or in the dot notation.
Because of that it is not possible to parse something like:
```json
{
  "42":"value",
  "default":true,
  "a key": "a value"
}
```
