### PR TITLE
Add null type

### DIFF
--- a/example.js
+++ b/example.js
@@ -4,7 +4,7 @@ const compile = require('./')
 const parse = compile.from({
   hello: 'string',
   num: 42,
-  testing: null,
+  null: null,
   flag: true,
   flags: [true],
   nested: {
@@ -13,8 +13,7 @@ const parse = compile.from({
 })
 
 const ex = JSON.stringify({
-  hello: 'world',
-  testing: null
+  hello: 'world'
 })
 
 // will return {hello: 'world'}

--- a/example.js
+++ b/example.js
@@ -4,6 +4,7 @@ const compile = require('./')
 const parse = compile.from({
   hello: 'string',
   num: 42,
+  testing: null,
   flag: true,
   flags: [true],
   nested: {
@@ -12,7 +13,8 @@ const parse = compile.from({
 })
 
 const ex = JSON.stringify({
-  hello: 'world'
+  hello: 'world',
+  testing: null
 })
 
 // will return {hello: 'world'}

--- a/lib/any.js
+++ b/lib/any.js
@@ -3,6 +3,7 @@ const numberDefaults = require('./number')
 const stringDefaults = require('./string')
 const booleanDefaults = require('./boolean')
 const arrayDefaults = require('./array')
+const nullDefaults = require('./null')
 const schema = require('./schema')
 
 module.exports = defaults
@@ -13,6 +14,7 @@ function defaults (opts) {
   const compileBoolean = booleanDefaults(opts)
   const compileObject = objectDefaults(opts)
   const compileArray = arrayDefaults(opts)
+  const compileNull = nullDefaults(opts)
 
   return compileAny
 
@@ -32,6 +34,10 @@ function defaults (opts) {
 
       case schema.OBJECT:
         compileObject(gen, prop, rawSchema, compileAny)
+        break
+
+      case schema.NULL:
+        compileNull(gen, prop)
         break
 
       case schema.ARRAY:

--- a/lib/null.js
+++ b/lib/null.js
@@ -1,0 +1,53 @@
+const ops = require('./ops')
+
+module.exports = defaults
+
+function defaults (opts) {
+  const { ch, code } = ops(opts)
+  const fullMatch = opts.fullMatch !== false
+
+  return compileNull
+
+  function compileNull (gen, prop) {
+    if (fullMatch) {
+      if (prop) {
+        gen(`
+          switch (${ch('ptr')}) {
+            case ${code('null')}:
+            ${prop.set('null', null)}
+            ptr += 4
+            break
+            default:
+            throw new Error("Unexpected token in null")
+          }
+        `)
+      } else {
+        gen(`
+          switch (${ch('ptr')}) {
+            case ${code('null')}:
+            parse.pointer = ptr + 4
+            return null
+            default:
+            throw new Error("Unexpected token in null")
+          }
+        `)
+      }
+    } else {
+      if (prop) {
+        gen(`
+          if (${ch('ptr')} === ${code('null')}) {
+            ${prop.set('null', null)}
+            ptr += 4
+          }
+        `)
+      } else {
+        gen(`
+          if(${ch('ptr')} === ${code('null')}) {
+            parse.pointer = ptr + 4
+            return null
+          }
+        `)
+      }
+    }
+  }
+}

--- a/lib/object.js
+++ b/lib/object.js
@@ -207,6 +207,9 @@ function defaults (opts) {
         case schema.BOOLEAN:
           gen(`${gen.property(f.name)}: ${f.default || false}${s}`)
           break
+        case schema.NULL:
+          gen(`${gen.property(f.name)}: ${f.default || null}${s}`)
+          break
         case schema.ARRAY:
           if (isRequired(f)) {
             gen(`${gen.property(f.name)}: []${s}`)

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -4,12 +4,14 @@ const BOOLEAN = exports.BOOLEAN = 2
 const ARRAY = exports.ARRAY = 3
 const OBJECT = exports.OBJECT = 4
 const UNKNOWN = exports.UNKNOWN = 5
+const NULL = exports.NULL = 6
 
 exports.inferRawSchema = (obj, opts) => inferRawSchema(obj, opts || {}, null)
 exports.jsonSchemaToRawSchema = convertToRawSchema
 
 function type (val) {
   if (Array.isArray(val)) return ARRAY
+  else if (val === null) return NULL
   switch (typeof val) {
     case 'string': return STRING
     case 'number': return NUMBER
@@ -41,6 +43,9 @@ function convertToRawSchema (jsons, opts) {
       break
     case 'boolean':
       s.type = BOOLEAN
+      break
+    case 'null':
+      s.type = NULL
       break
     case 'object':
       s.type = OBJECT

--- a/test/test.js
+++ b/test/test.js
@@ -421,5 +421,18 @@ t.test('turbo-json-parse', t => {
     })
   })
 
+  t.test('null', t => {
+    const parser = tjp({
+      type: 'object',
+      properties: {
+        key1: { type: 'null' }
+      }
+    })
+    t.deepEqual(parser('{"key1":null}'), {
+      key1: null
+    })
+    t.end()
+  })
+
   t.end()
 })


### PR DESCRIPTION
This is the first patch in a series of patches to get turbo-json-parse working with [scuttlebot](https://github.com/ssbc/scuttlebot). In json-schema null is a seperate type. We need it because we have strings that can be null, so I also have anyOf queued up, but one thing at a time :-)