### PR TITLE
Add anyOf support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ and is really fast assuming your JSON is type stable.
 const compile = require('turbo-json-parse')
 
 // Pass in a JSON schema
-// Note that only a subset of the schema is supported at the moment
-// including all of the type information, but excluding stuff like anyOf
-// PR welcome to expand to support :)
 
 const parse = compile({
   type: 'object',
@@ -30,6 +27,12 @@ const parse = compile({
       type: 'object',
       properties: {
         more: {type: 'string'}
+      }
+    },
+    maybeNull: {
+      anyOf: {
+        {type: 'string'},
+        {type: 'null'}
       }
     }
   }

--- a/lib/any.js
+++ b/lib/any.js
@@ -5,6 +5,7 @@ const booleanDefaults = require('./boolean')
 const arrayDefaults = require('./array')
 const nullDefaults = require('./null')
 const schema = require('./schema')
+const compileAnyOf = require('./anyOf')
 
 module.exports = defaults
 
@@ -42,6 +43,10 @@ function defaults (opts) {
 
       case schema.ARRAY:
         compileArray(gen, prop, rawSchema, compileAny)
+        break
+
+      case schema.ANY_OF:
+        compileAnyOf(gen, prop, rawSchema, compileAny)
         break
     }
   }

--- a/lib/anyOf.js
+++ b/lib/anyOf.js
@@ -1,39 +1,43 @@
 
 const schema = require('./schema')
 
+const numberCharCodes = [48, 49, 50, 51, 52, 53, 54, 55, 56, 57]
+
 module.exports = compileAnyOf
 
 function compileAnyOf (gen, prop, rawSchema, genany) {
-  const sym = gen.sym('codeAtPtr')
-  gen(`const ${sym} = s.charCodeAt(ptr)`)
+  gen(`switch (s.charCodeAt(ptr)) {`)
   for (let index = 0; index < rawSchema.types.length; index++) {
     const type = rawSchema.types[index]
-    gentypecheck(gen, prop, type, index, sym)
+    gentypecheck(gen, prop, type)
     genany(gen, prop, type)
+    gen('break')
   }
   gen('}')
 }
 
-function gentypecheck (gen, prop, type, index, sym) {
-  const elseIf = index === 0 ? '' : '} else '
+function gentypecheck (gen, prop, type) {
   switch (type.type) {
     case schema.STRING:
-      gen(elseIf + `if (${sym} === 34) {`)
+      gen('case 34:')
       break
     case schema.NUMBER:
-      gen(elseIf + `if ([48, 49, 50, 51, 52, 53, 54, 55, 56, 57].includes(${sym})) {`)
+      for (const code of numberCharCodes) {
+        gen(`case ${code}:`)
+      }
       break
     case schema.BOOLEAN:
-      gen(elseIf + `if ([102, 116].includes(${sym})) {`)
+      gen('case 102:')
+      gen('case 116:')
       break
     case schema.OBJECT:
-      gen(elseIf + `if (${sym} === 123) {`)
+      gen('case 123:')
       break
     case schema.ARRAY:
-      gen(elseIf + `if (${sym} === 91) {`)
+      gen('case 91:')
       break
     case schema.NULL:
-      gen(elseIf + `if (${sym} === 110) {`)
+      gen('case 110:')
       break
   }
 }

--- a/lib/anyOf.js
+++ b/lib/anyOf.js
@@ -4,35 +4,36 @@ const schema = require('./schema')
 module.exports = compileAnyOf
 
 function compileAnyOf (gen, prop, rawSchema, genany) {
-  gen('const codeAtPtr = s.charCodeAt(ptr)')
+  const sym = gen.sym('codeAtPtr')
+  gen(`const ${sym} = s.charCodeAt(ptr)`)
   for (let index = 0; index < rawSchema.types.length; index++) {
     const type = rawSchema.types[index]
-    gentypecheck(gen, prop, type, index)
+    gentypecheck(gen, prop, type, index, sym)
     genany(gen, prop, type)
   }
   gen('}')
 }
 
-function gentypecheck (gen, prop, type, index) {
+function gentypecheck (gen, prop, type, index, sym) {
   const elseIf = index === 0 ? '' : '} else '
   switch (type.type) {
     case schema.STRING:
-      gen(elseIf + 'if (codeAtPtr === 34) {')
+      gen(elseIf + `if (${sym} === 34) {`)
       break
     case schema.NUMBER:
-      gen(elseIf + 'if ([48, 49, 50, 51, 52, 53, 54, 55, 56, 57].includes(codeAtPtr)) {')
+      gen(elseIf + `if ([48, 49, 50, 51, 52, 53, 54, 55, 56, 57].includes(${sym})) {`)
       break
     case schema.BOOLEAN:
-      gen(elseIf + 'if ([102, 116].includes(codeAtPtr)) {')
+      gen(elseIf + `if ([102, 116].includes(${sym})) {`)
       break
     case schema.OBJECT:
-      gen(elseIf + 'if (codeAtPtr === 123) {')
+      gen(elseIf + `if (${sym} === 123) {`)
       break
     case schema.ARRAY:
-      gen(elseIf + 'if (codeAtPtr === 91) {')
+      gen(elseIf + `if (${sym} === 91) {`)
       break
     case schema.NULL:
-      gen(elseIf + 'if (codeAtPtr === 110) {')
+      gen(elseIf + `if (${sym} === 110) {`)
       break
   }
 }

--- a/lib/anyOf.js
+++ b/lib/anyOf.js
@@ -1,0 +1,38 @@
+
+const schema = require('./schema')
+
+module.exports = compileAnyOf
+
+function compileAnyOf (gen, prop, rawSchema, genany) {
+  gen('const codeAtPtr = s.charCodeAt(ptr)')
+  for (let index = 0; index < rawSchema.types.length; index++) {
+    const type = rawSchema.types[index]
+    gentypecheck(gen, prop, type, index)
+    genany(gen, prop, type)
+  }
+  gen('}')
+}
+
+function gentypecheck (gen, prop, type, index) {
+  const elseIf = index === 0 ? '' : '} else '
+  switch (type.type) {
+    case schema.STRING:
+      gen(elseIf + 'if (codeAtPtr === 34) {')
+      break
+    case schema.NUMBER:
+      gen(elseIf + 'if ([48, 49, 50, 51, 52, 53, 54, 55, 56, 57].includes(codeAtPtr)) {')
+      break
+    case schema.BOOLEAN:
+      gen(elseIf + 'if ([102, 116].includes(codeAtPtr)) {')
+      break
+    case schema.OBJECT:
+      gen(elseIf + 'if (codeAtPtr === 123) {')
+      break
+    case schema.ARRAY:
+      gen(elseIf + 'if (codeAtPtr === 91) {')
+      break
+    case schema.NULL:
+      gen(elseIf + 'if (codeAtPtr === 110) {')
+      break
+  }
+}

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -5,6 +5,7 @@ const ARRAY = exports.ARRAY = 3
 const OBJECT = exports.OBJECT = 4
 const UNKNOWN = exports.UNKNOWN = 5
 const NULL = exports.NULL = 6
+const ANY_OF = exports.ANY_OF = 7
 
 exports.inferRawSchema = (obj, opts) => inferRawSchema(obj, opts || {}, null)
 exports.jsonSchemaToRawSchema = convertToRawSchema
@@ -33,36 +34,41 @@ function convertToRawSchema (jsons, opts) {
     items: undefined
   }
 
-  switch (jsons.type) {
-    case 'integer':
-    case 'number':
-      s.type = NUMBER
-      break
-    case 'string':
-      s.type = STRING
-      break
-    case 'boolean':
-      s.type = BOOLEAN
-      break
-    case 'null':
-      s.type = NULL
-      break
-    case 'object':
-      s.type = OBJECT
-      s.fields = []
-      for (const k of Object.keys(jsons.properties)) {
-        const f = convertToRawSchema(jsons.properties[k], opts)
-        f.required = !!((jsons.required && jsons.required.indexOf(k) > -1) || jsons.properties[k].required)
-        f.name = k
-        s.fields.push(f)
-      }
-      break
-    case 'array':
-      s.type = ARRAY
-      s.items = jsons.items ? convertToRawSchema(jsons.items, opts) : null
-      break
-    default:
-      throw new Error('Unknown type: ' + jsons.type)
+  if (jsons.anyOf) {
+    s.type = ANY_OF
+    s.types = jsons.anyOf.map((t) => convertToRawSchema(t, opts))
+  } else {
+    switch (jsons.type) {
+      case 'integer':
+      case 'number':
+        s.type = NUMBER
+        break
+      case 'string':
+        s.type = STRING
+        break
+      case 'boolean':
+        s.type = BOOLEAN
+        break
+      case 'null':
+        s.type = NULL
+        break
+      case 'object':
+        s.type = OBJECT
+        s.fields = []
+        for (const k of Object.keys(jsons.properties)) {
+          const f = convertToRawSchema(jsons.properties[k], opts)
+          f.required = !!((jsons.required && jsons.required.indexOf(k) > -1) || jsons.properties[k].required)
+          f.name = k
+          s.fields.push(f)
+        }
+        break
+      case 'array':
+        s.type = ARRAY
+        s.items = jsons.items ? convertToRawSchema(jsons.items, opts) : null
+        break
+      default:
+        throw new Error('Unknown type: ' + jsons.type)
+    }
   }
 
   return s

--- a/test/anyOf.js
+++ b/test/anyOf.js
@@ -1,0 +1,252 @@
+'use strict'
+
+const t = require('tape')
+
+const tjp = require('../index')
+
+t.test('should parse anyOf string and null', t => {
+  t.plan(2)
+
+  const parser = tjp({
+    type: 'object',
+    properties: {
+      key1: {
+        anyOf: [
+          {
+            type: 'string'
+          },
+          {
+            type: 'null'
+          }
+        ]
+      }
+    }
+  })
+  t.deepEqual(parser('{"key1":"string"}'), {
+    key1: 'string'
+  })
+  t.deepEqual(parser('{"key1":null}'), {
+    key1: null
+  })
+})
+
+t.test('should parse anyOf string, boolean or null', t => {
+  t.plan(3)
+
+  const parser = tjp({
+    type: 'object',
+    properties: {
+      key1: {
+        anyOf: [
+          {
+            type: 'string'
+          },
+          {
+            type: 'null'
+          },
+          {
+            type: 'boolean'
+          }
+        ]
+      }
+    }
+  })
+  t.deepEqual(parser('{"key1":"string"}'), {
+    key1: 'string'
+  })
+  t.deepEqual(parser('{"key1":null}'), {
+    key1: null
+  })
+  t.deepEqual(parser('{"key1":true}'), {
+    key1: true
+  })
+})
+
+t.test('should parse anyOf array and null', t => {
+  t.plan(4)
+
+  const parser = tjp({
+    type: 'object',
+    properties: {
+      key1: {
+        anyOf: [
+          {
+            type: 'array',
+            items: {
+              type: 'string'
+            }
+          },
+          {
+            type: 'null'
+          }
+        ]
+      }
+    }
+  })
+  t.deepEqual(parser('{"key1":["string"]}'), {
+    key1: ['string']
+  })
+  t.deepEqual(parser('{"key1":["bird","cat"]}'), {
+    key1: ['bird', 'cat']
+  })
+  t.deepEqual(parser('{"key1":[]}'), {
+    key1: []
+  })
+  t.deepEqual(parser('{"key1":null}'), {
+    key1: null
+  })
+})
+
+t.test('should parse anyOf boolean and null', t => {
+  t.plan(3)
+
+  const parser = tjp({
+    type: 'object',
+    properties: {
+      key1: {
+        anyOf: [
+          {
+            type: 'boolean'
+          },
+          {
+            type: 'null'
+          }
+        ]
+      }
+    }
+  })
+  t.deepEqual(parser('{"key1":true}'), {
+    key1: true
+  })
+  t.deepEqual(parser('{"key1":false}'), {
+    key1: false
+  })
+  t.deepEqual(parser('{"key1":null}'), {
+    key1: null
+  })
+})
+
+t.test('should parse anyOf number and null', t => {
+  t.plan(12)
+
+  const parser = tjp({
+    type: 'object',
+    properties: {
+      key1: {
+        anyOf: [
+          {
+            type: 'number'
+          },
+          {
+            type: 'null'
+          }
+        ]
+      }
+    }
+  })
+  t.deepEqual(parser('{"key1":0}'), {
+    key1: 0
+  })
+  t.deepEqual(parser('{"key1":1}'), {
+    key1: 1
+  })
+  t.deepEqual(parser('{"key1":2}'), {
+    key1: 2
+  })
+  t.deepEqual(parser('{"key1":3}'), {
+    key1: 3
+  })
+  t.deepEqual(parser('{"key1":4}'), {
+    key1: 4
+  })
+  t.deepEqual(parser('{"key1":5}'), {
+    key1: 5
+  })
+  t.deepEqual(parser('{"key1":6}'), {
+    key1: 6
+  })
+  t.deepEqual(parser('{"key1":7}'), {
+    key1: 7
+  })
+  t.deepEqual(parser('{"key1":8}'), {
+    key1: 8
+  })
+  t.deepEqual(parser('{"key1":9}'), {
+    key1: 9
+  })
+  t.deepEqual(parser('{"key1":1.1}'), {
+    key1: 1.1
+  })
+  t.deepEqual(parser('{"key1":null}'), {
+    key1: null
+  })
+})
+
+t.test('should parse anyOf string and object', t => {
+  t.plan(2)
+
+  const parser = tjp({
+    type: 'object',
+    properties: {
+      key1: {
+        anyOf: [
+          {
+            type: 'string'
+          },
+          {
+            type: 'object',
+            properties: {
+              key2: {
+                type: 'string'
+              }
+            }
+          }
+        ]
+      }
+    }
+  })
+  t.deepEqual(parser('{"key1":"string"}'), {
+    key1: 'string'
+  })
+  t.deepEqual(parser('{"key1":{"key2":"blue"}}'), {
+    key1: {
+      key2: 'blue'
+    }
+  })
+})
+
+t.test('should parse anyOf string and null', t => {
+  t.plan(2)
+
+  const parser = tjp({
+    type: 'object',
+    properties: {
+      key0: {
+        type: 'boolean'
+      },
+      key1: {
+        anyOf: [
+          {
+            type: 'string'
+          },
+          {
+            type: 'null'
+          }
+        ]
+      },
+      key2: {
+        type: 'number'
+      }
+    }
+  })
+  t.deepEqual(parser('{"key0":true,"key1":"string","key2":42}'), {
+    key0: true,
+    key1: 'string',
+    key2: 42
+  })
+  t.deepEqual(parser('{"key0":true,"key1":null,"key2":42}'), {
+    key0: true,
+    key1: null,
+    key2: 42
+  })
+})

--- a/test/anyOf.js
+++ b/test/anyOf.js
@@ -30,6 +30,51 @@ t.test('should parse anyOf string and null', t => {
   })
 })
 
+t.test('should parse nested anyOf string and null', t => {
+  t.plan(3)
+
+  const parser = tjp({
+    type: 'object',
+    properties: {
+      key1: {
+        anyOf: [
+          {
+            type: 'object',
+            properties: {
+              key2: {
+                anyOf: [
+                  {
+                    type: 'string'
+                  },
+                  {
+                    type: 'null'
+                  }
+                ]
+              }
+            }
+          },
+          {
+            type: 'boolean'
+          }
+        ]
+      }
+    }
+  })
+  t.deepEqual(parser('{"key1":{"key2":"string"}}'), {
+    key1: {
+      key2: 'string'
+    }
+  })
+  t.deepEqual(parser('{"key1":{"key2":null}}'), {
+    key1: {
+      key2: null
+    }
+  })
+  t.deepEqual(parser('{"key1":false}'), {
+    key1: false
+  })
+})
+
 t.test('should parse anyOf string, boolean or null', t => {
   t.plan(3)
 


### PR DESCRIPTION
This adds support for `anyOf` and allows to combine multiple types in schemes.

For example it allows to parse strings that may be null as requested in #7 like this:

```
{
  type: 'object',
  properties: {
    key1: {
      anyOf: [
        {
          type: 'string'
        },
        {
          type: 'null'
        }
      ]
    }
  }
}
```
