### PR TITLE
Support prettyPrinted arrays and check for array start

### DIFF
--- a/lib/array.js
+++ b/lib/array.js
@@ -7,6 +7,7 @@ function defaults (opts) {
   const { ch, code } = ops(opts)
 
   const allowEmptyArrays = opts.allowEmptyArrays !== false
+  const prettyPrinted = !!opts.prettyPrinted
 
   return compileArray
 
@@ -20,6 +21,8 @@ function defaults (opts) {
       gen(`const ${a} = []`)
     }
 
+    gen(`if (${ch('ptr')} !== ${code('[')}) { throw new Error('Array does not start with [') }`)
+
     if (allowEmpty) {
       gen(`
         if (${ch('ptr + 1')} === ${code(']')}) {
@@ -30,12 +33,18 @@ function defaults (opts) {
 
     gen(`while (${ch('ptr++')} !== ${code(']')}) {`)
 
+    if (prettyPrinted)
+      gen(`while (${ch('ptr')} === ${code(' ')} || ${ch('ptr')} === ${code('\n')}) ptr++`) // whitespace
+
     if (!rawSchema.items) {
       gen(`throw new Error('Unknown array type')`)
     } else {
       const arrProp = new Property(gen, a, rawSchema.items)
       compileAny(gen, arrProp, rawSchema.items)
     }
+
+    if (prettyPrinted)
+      gen(`while (${ch('ptr')} === ${code(' ')} || ${ch('ptr')} === ${code('\n')}) ptr++`) // whitespace
 
     gen('}')
 

--- a/lib/array.js
+++ b/lib/array.js
@@ -33,8 +33,9 @@ function defaults (opts) {
 
     gen(`while (${ch('ptr++')} !== ${code(']')}) {`)
 
-    if (prettyPrinted)
-      gen(`while (${ch('ptr')} === ${code(' ')} || ${ch('ptr')} === ${code('\n')}) ptr++`) // whitespace
+    if (prettyPrinted) {
+      gen(`while (${ch('ptr')} === ${code(' ')} || ${ch('ptr')} === ${code('\n')}) ptr++`)
+    }
 
     if (!rawSchema.items) {
       gen(`throw new Error('Unknown array type')`)
@@ -43,8 +44,9 @@ function defaults (opts) {
       compileAny(gen, arrProp, rawSchema.items)
     }
 
-    if (prettyPrinted)
-      gen(`while (${ch('ptr')} === ${code(' ')} || ${ch('ptr')} === ${code('\n')}) ptr++`) // whitespace
+    if (prettyPrinted) {
+      gen(`while (${ch('ptr')} === ${code(' ')} || ${ch('ptr')} === ${code('\n')}) ptr++`)
+    }
 
     gen('}')
 


### PR DESCRIPTION
Arrays were not working properly when prettyPrinted. This fixes this.

Furthermore I added a check to make sure the array starts with [. I had a case where people would use an object instead of an array as the type specified which resulted in a infinite loop because it couldn't find the end of the array ;-)