### PR TITLE
Undefined defaults false object

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -204,8 +204,7 @@ function defaults (opts) {
     }
   }
 
-  function undefinedDefaultFields(gen, fields)
-  {
+  function undefinedDefaultFields (gen, fields) {
     if (!fields) fields = []
 
     for (var i = 0; i < fields.length; i++) {

--- a/lib/object.js
+++ b/lib/object.js
@@ -194,11 +194,25 @@ function defaults (opts) {
 
   function defaultObject (gen, name, rawSchema) {
     if (!defaults) {
-      gen(`const ${name} = {}`)
+      gen(`const ${name} = {`)
+      undefinedDefaultFields(gen, rawSchema.fields)
+      gen('}')
     } else {
       gen(`const ${name} = {`)
       defaultFields(gen, rawSchema.fields)
       gen('}')
+    }
+  }
+
+  function undefinedDefaultFields(gen, fields)
+  {
+    if (!fields) fields = []
+
+    for (var i = 0; i < fields.length; i++) {
+      const f = fields[i]
+      const s = i < fields.length - 1 ? ',' : ''
+
+      gen(`${gen.property(f.name)}: undefined${s}`)
     }
   }
 


### PR DESCRIPTION
So I was testing parsing 570k objects using turbo against json.parse and I wanted the resulting json to be the exactly the same, so I had to disabled defaults for this. The problem is that this made turbo around 4 seconds slower.

This change makes it so that `defaults: false` actually defines all the properties but just as undefined so that if you do a JSON.stringify afterwards you get exactly the same result as if you did not define the fields and now it is fast again.