### PR TITLE
More verbose error messages for unexpected tokens

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -111,7 +111,7 @@ function defaults (opts) {
       genifs(gen, o, fields, genany)
       gen(`
         if (${ch('ptr++')} !== ${code('}')}) {
-          throw new Error('Unexpected token in object')
+          throw new Error('Unexpected token "' + String.fromCharCode(${ch('ptr - 1')}) +'" in object (offset: ' + (ptr - 1) + ')')
         }
       `)
     } else {


### PR DESCRIPTION
This will print something like:

```plain
Unexpected token "," in object (offset: 875)
```

rather than just:

```plain
Unexpected token in object
```

I believe this can help a lot with debugging errors